### PR TITLE
feat(serial_monitor): monitor serial can exclude something

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -45,6 +45,7 @@ alias gif_recorder='~/envconfig/utils/gif_recorder'
 source ~/envconfig/ros_install.zsh
 source ~/envconfig/beuzclone.zsh
 source ~/envconfig/nordvpn.zsh
+source ~/envconfig/serial_monitor.zsh
 
 source ~/.custom.zsh
 

--- a/serial_listenner.zsh
+++ b/serial_listenner.zsh
@@ -1,0 +1,8 @@
+serial_listenner(){
+    #socat stdio $(/dev/$1) | grep -v $("$2")
+    if [ "$#" -eq 2 ]; then
+    	socat stdio /dev/$1 | grep -v "$2"
+    else
+    	socat stdio /dev/$1 
+    fi
+}


### PR DESCRIPTION
usage:
`serial_monitor ttyACM0`
`serial_monitor ttyACM0 plotline` to remove lines containing the string plotline